### PR TITLE
fix: restore heading color after inline formatting

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -756,8 +756,14 @@ impl StreamingParser {
     fn format_heading(&self, level: usize, text: &str) -> String {
         let formatted_text = self.format_inline(text);
         // Heading: blue and bold, with line break after for spacing
+        // Replace any ANSI reset codes within the formatted text to restore heading style
+        // This prevents inline formatting (like _italic_) from breaking the heading color
+        let heading_style = "\u{001b}[1;34m";
+        let formatted_text =
+            formatted_text.replace("\u{001b}[0m", &format!("\u{001b}[0m{}", heading_style));
         format!(
-            "\u{001b}[1;34m{} {}\u{001b}[0m\n\n",
+            "{}{} {}\u{001b}[0m\n\n",
+            heading_style,
             "#".repeat(level),
             formatted_text
         )

--- a/tests/fixtures/blocks/heading_inline_formatting.toml
+++ b/tests/fixtures/blocks/heading_inline_formatting.toml
@@ -1,0 +1,19 @@
+name = "heading-inline-formatting"
+description = "Heading with inline formatting should restore heading style after inline elements"
+
+# This test verifies that when inline formatting (like _italic_) appears within
+# a heading, the heading color/style is properly restored after the inline
+# formatting ends. Before the fix, the reset code at the end of italic would
+# reset ALL formatting, causing text after the italic to lose the heading color.
+
+[[chunks]]
+input = "## Do you like the _Black_ code style?\n"
+emit = "\u001b[1;34m## Do you like the \u001b[3mBlack\u001b[0m\u001b[1;34m code style?\u001b[0m\n\n"
+
+[[chunks]]
+input = "# A **bold** heading\n"
+emit = "\u001b[1;34m# A \u001b[1mbold\u001b[0m\u001b[1;34m heading\u001b[0m\n\n"
+
+[[chunks]]
+input = "### Mixed _italic_ and **bold** text\n"
+emit = "\u001b[1;34m### Mixed \u001b[3mitalic\u001b[0m\u001b[1;34m and \u001b[1mbold\u001b[0m\u001b[1;34m text\u001b[0m\n\n"


### PR DESCRIPTION
## Summary
- Fixed bug where inline formatting (like `_italic_`) in headings would break the heading color
- The ANSI reset code (`\x1b[0m`) at the end of inline elements was resetting ALL formatting, including the heading's blue+bold style
- Fix replaces reset codes in inline-formatted heading text with reset-then-restore sequences

## Test plan
- [x] Added test fixture `heading_inline_formatting.toml` with 3 test cases
- [x] Verified test fails without the fix (26 passed, 1 failed)
- [x] All 43 tests pass with the fix
- [x] `cargo fmt`, `cargo build`, and `cargo clippy` all pass

## Session transcript
[Claude Code session transcript](https://gist.github.com/llimllib/9efc94489d17ae9fd9795784fb450799)

🤖 Generated with [Claude Code](https://claude.com/claude-code)