### PR TITLE
fix: exclude build artifacts from crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,6 +9,7 @@ readme = "README.md"
 keywords = ["markdown", "terminal", "cli", "streaming", "syntax-highlighting"]
 categories = ["command-line-utilities", "text-processing"]
 authors = ["Bill Mill <bill@billmill.org>"]
+exclude = ["mdriver-*"]
 
 [[bin]]
 name = "mdriver"


### PR DESCRIPTION
## Summary
- Add `exclude = ["mdriver-*"]` to Cargo.toml to prevent downloaded binary artifacts from being included in the crates.io package

## Problem
The release workflow downloads binary artifacts (for GitHub release attachments) before running `cargo publish`. These ~15MB of artifacts were being included in the crate package, exceeding crates.io's 10MB limit.

## Test plan
- [ ] Re-run the release workflow and verify the package uploads successfully
- [ ] Verify the crate on crates.io contains only source files

## Session transcript
[Claude Code session transcript](https://gist.github.com/llimllib/7a2b179c8bf600f252f85d3562bbb927)

🤖 Generated with [Claude Code](https://claude.com/claude-code)