### PR TITLE
feat: add --version flag with rustc info

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,16 @@
+use std::process::Command;
+
+fn main() {
+    // Capture rustc version at compile time
+    let rustc_version = Command::new("rustc")
+        .arg("--version")
+        .output()
+        .ok()
+        .and_then(|output| String::from_utf8(output.stdout).ok())
+        .unwrap_or_else(|| "unknown".to_string());
+
+    println!("cargo:rustc-env=RUSTC_VERSION={}", rustc_version.trim());
+
+    // Re-run if rustc changes
+    println!("cargo:rerun-if-env-changed=RUSTC");
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,11 @@ use std::env;
 use std::fs::File;
 use std::io::{self, Read};
 
+fn print_version() {
+    println!("mdriver {}", env!("CARGO_PKG_VERSION"));
+    println!("rustc: {}", env!("RUSTC_VERSION"));
+}
+
 fn print_help() {
     println!("mdriver - Streaming Markdown Printer");
     println!();
@@ -10,6 +15,7 @@ fn print_help() {
     println!("    mdriver [OPTIONS] [FILE]");
     println!();
     println!("OPTIONS:");
+    println!("    --version, -V       Print version information");
     println!("    --help              Print this help message");
     println!("    --list-themes       List available syntax highlighting themes");
     println!("    --theme <THEME>     Use specified syntax highlighting theme");
@@ -44,6 +50,10 @@ fn main() -> io::Result<()> {
 
     while i < args.len() {
         match args[i].as_str() {
+            "--version" | "-V" => {
+                print_version();
+                return Ok(());
+            }
             "--help" | "-h" => {
                 print_help();
                 return Ok(());


### PR DESCRIPTION
## Summary
- Add `--version` / `-V` flag that prints version and compilation info
- Uses `build.rs` to capture rustc version at compile time
- Output example:
  ```
  mdriver 0.7.0
  rustc: rustc 1.92.0 (ded5c06cf 2025-12-08)
  ```

## Test plan
- [x] `cargo fmt` - passes
- [x] `cargo build` - no warnings
- [x] `cargo clippy --all-targets --all-features -- -D warnings` - passes
- [x] `cargo test` - all tests pass
- [x] `mdriver --version` - prints version info
- [x] `mdriver -V` - prints version info
- [x] `mdriver --help` - shows new flag in options

## Session transcript
[Claude Code session transcript](https://gist.github.com/llimllib/893649d138146831cc2ffc780998151b)

🤖 Generated with [Claude Code](https://claude.com/claude-code)