### PR TITLE
feat: add HTML entity support

### DIFF
--- a/README.md
+++ b/README.md
@@ -187,6 +187,69 @@ mdriver --images kitty document.md
 
 **Note**: Image rendering requires a terminal that supports the kitty graphics protocol. In terminals without support, images will display as alt text.
 
+## HTML Entity Support
+
+mdriver decodes HTML entities in markdown text, supporting both named entities and numeric character references.
+
+### Supported Named Entities
+
+| Entity | Character | Description |
+|--------|-----------|-------------|
+| **Essential (XML)** |
+| `&amp;` | `&` | Ampersand |
+| `&lt;` | `<` | Less than |
+| `&gt;` | `>` | Greater than |
+| `&quot;` | `"` | Quotation mark |
+| `&apos;` | `'` | Apostrophe |
+| **Whitespace** |
+| `&nbsp;` | | Non-breaking space |
+| **Typographic** |
+| `&ndash;` | `–` | En dash |
+| `&mdash;` | `—` | Em dash |
+| `&hellip;` | `…` | Horizontal ellipsis |
+| `&lsquo;` | `'` | Left single quote |
+| `&rsquo;` | `'` | Right single quote |
+| `&ldquo;` | `"` | Left double quote |
+| `&rdquo;` | `"` | Right double quote |
+| `&bull;` | `•` | Bullet |
+| `&middot;` | `·` | Middle dot |
+| **Symbols** |
+| `&copy;` | `©` | Copyright |
+| `&reg;` | `®` | Registered |
+| `&trade;` | `™` | Trademark |
+| `&deg;` | `°` | Degree |
+| `&plusmn;` | `±` | Plus-minus |
+| `&times;` | `×` | Multiplication |
+| `&divide;` | `÷` | Division |
+| **Fractions** |
+| `&frac14;` | `¼` | One quarter |
+| `&frac12;` | `½` | One half |
+| `&frac34;` | `¾` | Three quarters |
+| **Currency** |
+| `&cent;` | `¢` | Cent |
+| `&pound;` | `£` | Pound |
+| `&euro;` | `€` | Euro |
+| `&yen;` | `¥` | Yen |
+| **Arrows** |
+| `&larr;` | `←` | Left arrow |
+| `&rarr;` | `→` | Right arrow |
+| `&uarr;` | `↑` | Up arrow |
+| `&darr;` | `↓` | Down arrow |
+
+### Numeric Character References
+
+In addition to named entities, mdriver supports numeric references for any Unicode character:
+
+- **Decimal**: `&#169;` → `©`
+- **Hexadecimal**: `&#x00A9;` → `©`
+
+### Example
+
+```bash
+$ echo "5 &lt; 10 &mdash; Tom &amp; Jerry &copy; 2024" | mdriver
+5 < 10 — Tom & Jerry © 2024
+```
+
 ## Conformance Test Suite
 
 This project uses a comprehensive conformance test suite to verify streaming behavior, markdown parsing, and ANSI formatting.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::sync::LazyLock;
 
 use syntect::easy::HighlightLines;
@@ -7,6 +8,52 @@ use two_face::theme::{EmbeddedLazyThemeSet, EmbeddedThemeName};
 
 // Static theme set using two-face's extended themes
 static THEME_SET: LazyLock<EmbeddedLazyThemeSet> = LazyLock::new(two_face::theme::extra);
+
+// HTML entity lookup table
+static HTML_ENTITIES: LazyLock<HashMap<&'static str, char>> = LazyLock::new(|| {
+    let mut m = HashMap::new();
+    // Essential (XML) entities
+    m.insert("amp", '&');
+    m.insert("lt", '<');
+    m.insert("gt", '>');
+    m.insert("quot", '"');
+    m.insert("apos", '\'');
+    // Whitespace
+    m.insert("nbsp", '\u{00A0}');
+    // Typographic
+    m.insert("ndash", '–');
+    m.insert("mdash", '—');
+    m.insert("hellip", '…');
+    m.insert("lsquo", '\u{2018}'); // '
+    m.insert("rsquo", '\u{2019}'); // '
+    m.insert("ldquo", '\u{201C}'); // "
+    m.insert("rdquo", '\u{201D}'); // "
+    m.insert("bull", '•');
+    m.insert("middot", '·');
+    // Symbols
+    m.insert("copy", '©');
+    m.insert("reg", '®');
+    m.insert("trade", '™');
+    m.insert("deg", '°');
+    m.insert("plusmn", '±');
+    m.insert("times", '×');
+    m.insert("divide", '÷');
+    // Fractions
+    m.insert("frac14", '¼');
+    m.insert("frac12", '½');
+    m.insert("frac34", '¾');
+    // Currency
+    m.insert("cent", '¢');
+    m.insert("pound", '£');
+    m.insert("euro", '€');
+    m.insert("yen", '¥');
+    // Arrows
+    m.insert("larr", '←');
+    m.insert("rarr", '→');
+    m.insert("uarr", '↑');
+    m.insert("darr", '↓');
+    m
+});
 
 /// Column alignment in tables
 #[derive(Debug, Clone, Copy, PartialEq)]
@@ -1497,6 +1544,15 @@ impl StreamingParser {
                 }
             }
 
+            // Check for HTML entities (&amp;, &#123;, &#x7B;)
+            if chars[i] == '&' {
+                if let Some((decoded, consumed)) = decode_html_entity(&chars, i) {
+                    result.push(decoded);
+                    i += consumed;
+                    continue;
+                }
+            }
+
             result.push(chars[i]);
             i += 1;
         }
@@ -1897,4 +1953,73 @@ impl Default for StreamingParser {
     fn default() -> Self {
         Self::new()
     }
+}
+
+/// Try to decode an HTML entity starting at the given position.
+/// Returns Some((decoded_char, chars_consumed)) if an entity is found, None otherwise.
+/// Supports named entities (&amp;), decimal numeric (&#123;), and hex numeric (&#x7B;).
+fn decode_html_entity(chars: &[char], start: usize) -> Option<(char, usize)> {
+    // Must start with '&'
+    if start >= chars.len() || chars[start] != '&' {
+        return None;
+    }
+
+    // Find the semicolon (entity terminator) or end of entity name
+    let mut end = start + 1;
+    while end < chars.len() && end - start < 12 {
+        // Max reasonable entity length
+        if chars[end] == ';' {
+            break;
+        }
+        // Stop if we hit a character that can't be part of an entity name
+        if chars[end].is_whitespace() || chars[end] == '&' {
+            break;
+        }
+        // Entity names are alphanumeric (and # for numeric entities)
+        if !chars[end].is_ascii_alphanumeric() && chars[end] != '#' {
+            break;
+        }
+        end += 1;
+    }
+
+    // Check if we found a semicolon, but also allow entities without semicolon
+    let has_semicolon = end < chars.len() && chars[end] == ';';
+
+    // Extract the entity content (without & and optional ;)
+    if end <= start + 1 {
+        return None;
+    }
+
+    let entity_content: String = chars[start + 1..end].iter().collect();
+
+    // Try numeric entity (decimal or hex)
+    if let Some(num_str) = entity_content.strip_prefix('#') {
+        let codepoint = if let Some(hex) = num_str
+            .strip_prefix('x')
+            .or_else(|| num_str.strip_prefix('X'))
+        {
+            u32::from_str_radix(hex, 16).ok()?
+        } else {
+            num_str.parse::<u32>().ok()?
+        };
+        let decoded = char::from_u32(codepoint)?;
+        let consumed = if has_semicolon {
+            end - start + 1
+        } else {
+            end - start
+        };
+        return Some((decoded, consumed));
+    }
+
+    // Try named entity (with semicolon required for lookup, or without)
+    if let Some(&decoded) = HTML_ENTITIES.get(entity_content.as_str()) {
+        let consumed = if has_semicolon {
+            end - start + 1
+        } else {
+            end - start
+        };
+        return Some((decoded, consumed));
+    }
+
+    None
 }


### PR DESCRIPTION
## Summary

- Add support for decoding 32 named HTML entities (amp, lt, gt, nbsp, mdash, copy, etc.)
- Add support for numeric character references (decimal `&#169;` and hex `&#x00A9;`)
- Add comprehensive test suite with 28 new tests
- Document supported entities in README

## Test plan

- [x] All 66 unit tests pass
- [x] All 5 conformance tests pass
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt` applied

## Session transcript

[Claude Code session transcript](https://gist.github.com/llimllib/1f72daf187a30880a3196f17b364dff9)

🤖 Generated with [Claude Code](https://claude.ai/code)