### PR TITLE
fix: use configured width for horizontal rules instead of terminal detection

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1164,9 +1164,7 @@ impl StreamingParser {
 
     fn format_horizontal_rule(&self) -> String {
         // Use a line of dashes with dim/gray color
-        // Terminal width aware, but default to 80 if unavailable
-        let width = term_size::dimensions().map(|(w, _)| w).unwrap_or(80);
-        let rule = "─".repeat(width);
+        let rule = "─".repeat(self.width);
         format!("\u{001b}[2m{}\u{001b}[0m\n\n", rule)
     }
 

--- a/tests/fixtures/blocks/horizontal_rule_asterisks.toml
+++ b/tests/fixtures/blocks/horizontal_rule_asterisks.toml
@@ -1,5 +1,6 @@
 name = "horizontal-rule-asterisks"
 description = "Horizontal rule with *** should emit immediately"
+width = 80
 
 [[chunks]]
 input = "***\n"

--- a/tests/fixtures/blocks/horizontal_rule_basic.toml
+++ b/tests/fixtures/blocks/horizontal_rule_basic.toml
@@ -1,5 +1,6 @@
 name = "horizontal-rule-basic"
 description = "Basic horizontal rule with --- should emit immediately"
+width = 80
 
 [[chunks]]
 input = "---\n"

--- a/tests/fixtures/blocks/horizontal_rule_in_list.toml
+++ b/tests/fixtures/blocks/horizontal_rule_in_list.toml
@@ -1,5 +1,6 @@
 name = "horizontal-rule-in-list"
 description = "Horizontal rule should interrupt a list"
+width = 80
 
 [[chunks]]
 input = "- Foo\n"

--- a/tests/fixtures/blocks/horizontal_rule_spaces.toml
+++ b/tests/fixtures/blocks/horizontal_rule_spaces.toml
@@ -1,5 +1,6 @@
 name = "horizontal-rule-spaces"
 description = "Horizontal rule with spaces between characters"
+width = 80
 
 [[chunks]]
 input = "- - -\n"


### PR DESCRIPTION
## Summary
- Fixed `format_horizontal_rule()` to use `self.width` instead of calling `term_size::dimensions()` directly
- This bug caused horizontal rules to render at actual terminal width instead of configured width, causing test failures on terminals wider than 80 columns
- Added explicit `width = 80` to horizontal rule test fixtures for determinism

## Test plan
- [x] All tests pass with `cargo test`
- [x] `cargo clippy` passes with no warnings
- [x] `cargo fmt -- --check` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)