### PR TITLE
feat: add SVG image support via resvg

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ ureq = "2.9"
 image = "0.25"
 base64 = "0.22"
 term_size = "0.3"
+resvg = "0.45"
 
 [dev-dependencies]
 serde = { version = "1.0", features = ["derive"] }

--- a/tests/unit.rs
+++ b/tests/unit.rs
@@ -590,16 +590,14 @@ mod image_inside_link {
     #[test]
     fn test_markdown_image_inside_link() {
         // [![alt](img-src)](link-url) pattern
-        // Note: This is a known limitation - nested markdown brackets don't parse correctly.
-        // The parser finds the first `]` instead of the matching one, so this becomes
-        // a link with text "![Badge" and URL from the image src.
-        // For proper nested image-in-link, use HTML: [<img src="..." alt="..."/>](url)
+        // The parser correctly handles nested brackets, extracting the image from the link text
+        // and the link URL from the outer structure.
         let p = parser();
         let result =
             p.format_inline("[![Badge](https://example.com/badge.svg)](https://example.com)");
         let stripped = strip_ansi(&result);
-        // Current behavior: parses as link with text "![Badge" and URL "https://example.com/badge.svg"
-        assert_eq!(stripped, "![Badge](https://example.com)");
+        // Link text contains the image (rendered as markdown since ImageProtocol::None)
+        assert_eq!(stripped, "![Badge](https://example.com/badge.svg)");
     }
 
     #[test]


### PR DESCRIPTION
## Summary
- Add SVG image support using resvg with system font loading for proper text rendering
- Fix nested bracket parsing to correctly handle linked images like `[![alt](img)](url)`
- Add APC sequence handling so Kitty graphics work correctly with text wrapping
- Remove trailing newlines from images to allow inline display of consecutive badges

Badge images without file extensions (like GitHub Actions, Codecov, etc.) now display correctly as images in terminals with Kitty graphics support.

## Test plan
- [x] Verify SVG badges render with text (e.g., GitHub Actions badge with "Test" and "no status")
- [x] Verify multiple consecutive badges display on a single line
- [x] Verify linked images `[![alt](img)](url)` parse correctly
- [x] Run `cargo test` - all 105 tests pass
- [x] Run `cargo clippy` - no warnings

## Session transcript
[Claude Code session transcript](https://gist.github.com/llimllib/6e8b8c6cea75e0c249ba0195b0603585)

🤖 Generated with [Claude Code](https://claude.com/claude-code)