### PR TITLE
feat: auto-populate changelog and add shellcheck CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ jobs:
       matrix:
         os: [ubuntu-latest, macos-latest]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Run tests
@@ -25,3 +25,12 @@ jobs:
 
       - name: Check formatting
         run: cargo fmt -- --check
+
+  shellcheck:
+    name: Shellcheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - name: Run shellcheck
+        run: find . -name '*.sh' -type f | xargs shellcheck

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -20,7 +20,7 @@ jobs:
             target: aarch64-apple-darwin
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
 
       - name: Install target
@@ -48,7 +48,7 @@ jobs:
       contents: write
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       - uses: dtolnay/rust-toolchain@stable
       - uses: actions/download-artifact@v6
 


### PR DESCRIPTION
## Summary

- Release script now automatically populates changelog from git commit messages since the last tag, removing the manual editing prompt
- Added shellcheck job to CI workflow to lint all shell scripts
- Updated actions/checkout from v4 to v6 in all workflows

## Test plan

- [ ] Run `shellcheck tools/release.sh` locally to verify it passes
- [ ] Test release script workflow (without actually releasing) to verify changelog population works

## Session transcript
[Claude Code session transcript](https://gist.github.com/llimllib/85e17922ec27b4dd513d54d23cfeb1bc)

🤖 Generated with [Claude Code](https://claude.com/claude-code)