### PR TITLE
fix: parse task list items instead of treating them as reference links

### DIFF
--- a/task.md
+++ b/task.md
@@ -1,0 +1,10 @@
+# Task
+
+A completed item in a github-flavored todo list is getting parsed as if it is a referenced link
+
+- [x] completed TODO
+- [x] another completed TODO
+- [ ] open TODO
+- [ ] bananas
+
+Please parse this as a task list, not as two links labeled `x`


### PR DESCRIPTION
## Summary

Task list items like `- [x] completed` and `- [ ] open` were incorrectly being treated as reference links with label 'x' or ' '.

## Changes

- Add `parse_task_list_marker()` to detect GFM task list markers
- Modify `format_list()` to render task items with checkboxes (☑/☐)
- Checkboxes replace the bullet marker rather than appearing after it
- Add 8 unit tests for task list functionality

## Output

```
  ☑ completed TODO
  ☑ another completed TODO
  ☐ open TODO
  ☐ bananas
```

## Session transcript

[Claude Code session transcript](https://gist.github.com/llimllib/c28fe3a5ca4a3b23b5d5687f7e0caa4d)